### PR TITLE
cross account role import bug fix using mutable to False

### DIFF
--- a/mlops-multi-account-cdk/mlops-sm-project-template/mlops_sm_project_template/templates/byoc_pipeline_constructs/deploy_pipeline_construct.py
+++ b/mlops-multi-account-cdk/mlops-sm-project-template/mlops_sm_project_template/templates/byoc_pipeline_constructs/deploy_pipeline_construct.py
@@ -291,11 +291,13 @@ class DeployPipelineConstruct(Construct):
                         self,
                         "PreProdActionRole",
                         f"arn:{Aws.PARTITION}:iam::{preprod_account}:role/cdk-hnb659fds-deploy-role-{preprod_account}-{deployment_region}",
+                        mutable=False,
                     ),
                     deployment_role=iam.Role.from_role_arn(
                         self,
                         "PreProdDeploymentRole",
                         f"arn:{Aws.PARTITION}:iam::{preprod_account}:role/cdk-hnb659fds-cfn-exec-role-{preprod_account}-{deployment_region}",
+                        mutable=False,
                     ),
                     cfn_capabilities=[
                         CfnCapabilities.AUTO_EXPAND,
@@ -324,11 +326,13 @@ class DeployPipelineConstruct(Construct):
                         self,
                         "ProdActionRole",
                         f"arn:{Aws.PARTITION}:iam::{prod_account}:role/cdk-hnb659fds-deploy-role-{prod_account}-{deployment_region}",
+                        mutable=False,
                     ),
                     deployment_role=iam.Role.from_role_arn(
                         self,
                         "ProdDeploymentRole",
                         f"arn:{Aws.PARTITION}:iam::{prod_account}:role/cdk-hnb659fds-cfn-exec-role-{prod_account}-{deployment_region}",
+                        mutable=False,
                     ),
                     cfn_capabilities=[
                         CfnCapabilities.AUTO_EXPAND,

--- a/mlops-multi-account-cdk/mlops-sm-project-template/mlops_sm_project_template/templates/pipeline_constructs/deploy_pipeline_construct.py
+++ b/mlops-multi-account-cdk/mlops-sm-project-template/mlops_sm_project_template/templates/pipeline_constructs/deploy_pipeline_construct.py
@@ -311,11 +311,13 @@ class DeployPipelineConstruct(Construct):
                         self,
                         "PreProdActionRole",
                         f"arn:{Aws.PARTITION}:iam::{preprod_account}:role/cdk-hnb659fds-deploy-role-{preprod_account}-{deployment_region}",
+                        mutable=False,
                     ),
                     deployment_role=iam.Role.from_role_arn(
                         self,
                         "PreProdDeploymentRole",
                         f"arn:{Aws.PARTITION}:iam::{preprod_account}:role/cdk-hnb659fds-cfn-exec-role-{preprod_account}-{deployment_region}",
+                        mutable=False,
                     ),
                     cfn_capabilities=[
                         CfnCapabilities.AUTO_EXPAND,
@@ -344,11 +346,13 @@ class DeployPipelineConstruct(Construct):
                         self,
                         "ProdActionRole",
                         f"arn:{Aws.PARTITION}:iam::{prod_account}:role/cdk-hnb659fds-deploy-role-{prod_account}-{deployment_region}",
+                        mutable=False,
                     ),
                     deployment_role=iam.Role.from_role_arn(
                         self,
                         "ProdDeploymentRole",
                         f"arn:{Aws.PARTITION}:iam::{prod_account}:role/cdk-hnb659fds-cfn-exec-role-{prod_account}-{deployment_region}",
+                        mutable=False,
                     ),
                     cfn_capabilities=[
                         CfnCapabilities.AUTO_EXPAND,


### PR DESCRIPTION
cross account role import bug fix:

Issue:
Dev account pipeline use role(action role, deployment role) from target account like preprod , prod. These imported roles are getting updated which is causing issue and result into failure. Dev pipeline looks for a target account policy in dev account which will obviously will not be there in dev account. 

Fix:
Imported role should not be modified. To achieve this, we can arrange mutable=False as an argument while importing role using 'iam.Role.from_role_arn'